### PR TITLE
fix(updater): include app target so updater artifacts are produced

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "dmg",
+    "targets": ["app", "dmg"],
     "createUpdaterArtifacts": true,
     "externalBin": ["binaries/cork-cli"],
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns"],


### PR DESCRIPTION
## Summary

The v0.16.0 release job ([failed run](https://github.com/koki-develop/Cork/actions/runs/28207927077/job/83562691656)) couldn't find `*.app.tar.gz` / `*.app.tar.gz.sig` under `src-tauri/target/release/bundle/macos/`. Root cause: `bundle.targets` was set to `"dmg"` only, but Tauri's updater post-processor only walks the user-specified targets, not the implicit `.app` build the DMG bundler runs internally.

In `crates/tauri-bundler/src/bundle.rs:207-220` the updater bundle is created only if `package_types` contains `PackageType::MacOsBundle`. The string mapping at `bundle/settings.rs:88` confirms `MacOsBundle ↔ "app"`. With `targets: "dmg"` the user-supplied list has only `Dmg`, so the updater branch logs `"no updater-enabled targets were built"` and produces nothing.

Adding `"app"` to the targets array makes Tauri:

1. Build the standalone `Cork.app` under `bundle/macos/` via the macOS app bundler
2. Produce `Cork.app.tar.gz` + `Cork.app.tar.gz.sig` via the updater post-processor (now satisfied because `MacOsBundle` is in `package_types`)
3. Still build `Cork.dmg` under `bundle/dmg/` via the DMG bundler

Both upload-artifact steps (`name: dmg` and `name: updater-bundle`) now find their inputs.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [ ] Cut the next patch release and confirm both `dmg` and `updater-bundle` upload steps succeed
- [ ] Confirm `latest.json` generation step picks up the `.app.tar.gz.sig` via the existing `ls artifacts/*.app.tar.gz.sig | head -1` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)