### PR TITLE
fix(updater): rename .app.tar.gz to versioned form before release upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,6 +85,13 @@ jobs:
           path: artifacts
       - name: Upload DMG and updater bundle
         run: |
+          # Tauri writes the updater bundle as plain `Cork.app.tar.gz` (the
+          # macOS bundler just appends `.tar.gz` to the .app path), so we
+          # rename it to the versioned/arch form to parallel the DMG naming
+          # and to match the URL pattern in `scripts/build-update-manifest.ts`.
+          VERSION="${TAG_NAME#v}"
+          mv artifacts/Cork.app.tar.gz "artifacts/Cork_${VERSION}_aarch64.app.tar.gz"
+          mv artifacts/Cork.app.tar.gz.sig "artifacts/Cork_${VERSION}_aarch64.app.tar.gz.sig"
           gh release upload "$TAG_NAME" \
             artifacts/*.dmg \
             artifacts/*.app.tar.gz \


### PR DESCRIPTION
## Summary

The previous updater-enabled release shipped \`Cork.app.tar.gz\` and \`Cork.app.tar.gz.sig\` as release assets, but the manifest URL in \`scripts/build-update-manifest.ts\` points at \`Cork_<version>_aarch64.app.tar.gz\` (parallel to the DMG naming). Clicking \`Install and Restart\` hit:

\`\`\`
Download request failed with status: 404 Not Found
\`\`\`

Tauri's macOS updater bundler just appends \`.tar.gz\` to the .app source path (\`crates/tauri-bundler/src/bundle/updater_bundle.rs:66\`), so the raw output is \`Cork.app.tar.gz\` — unversioned and arch-less. The DMG bundler, by contrast, writes \`Cork_<version>_aarch64.dmg\`.

This rename step in the \`release\` job aligns the two: the assets ship as \`Cork_<version>_aarch64.app.tar.gz\` / \`.sig\`, matching the URL the manifest generator already constructs. The \`SIG_FILE=$(ls artifacts/*.app.tar.gz.sig | head -1)\` lookup still resolves to the renamed file, so \`build-update-manifest.ts\` keeps working untouched.

## Recovery for the failing release

The release that's currently 404'ing needs a one-time manual fix (the rename step here only takes effect from the next release onward). Two options on the existing release:

1. Rename the assets on the GitHub release: \`gh release download \$TAG_NAME -p '*.app.tar.gz*' && mv Cork.app.tar.gz Cork_\${VERSION}_aarch64.app.tar.gz && mv Cork.app.tar.gz.sig Cork_\${VERSION}_aarch64.app.tar.gz.sig && gh release upload \$TAG_NAME Cork_*.app.tar.gz* --clobber\`
2. Or cut another patch release once this is merged — \`release-please\` will generate the manifest with the correct URL automatically.

## Test plan

- [ ] Cut a patch release after merge; confirm release assets are named \`Cork_<version>_aarch64.app.tar.gz\` and the in-app \`Install and Restart\` completes the download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)