### PR TITLE
fix(updater): match Tauri's default Cork.app.tar.gz filename in manifest URL

### DIFF
--- a/scripts/build-update-manifest.ts
+++ b/scripts/build-update-manifest.ts
@@ -17,7 +17,7 @@ function buildManifest(args: { version: string; signature: string; notes: string
     platforms: {
       "darwin-aarch64": {
         signature: args.signature,
-        url: `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/v${args.version}/Cork_${args.version}_aarch64.app.tar.gz`,
+        url: `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/v${args.version}/Cork.app.tar.gz`,
       },
     },
   };


### PR DESCRIPTION
## Summary

The previous updater-enabled release shipped the .app.tar.gz under the name Tauri itself emits — \`Cork.app.tar.gz\` — but the manifest URL was constructing the parallel-to-DMG form \`Cork_<version>_aarch64.app.tar.gz\`. The client hit:

\`\`\`
Download request failed with status: 404 Not Found
\`\`\`

Tauri's macOS updater bundler just appends \`.tar.gz\` to the .app path (\`crates/tauri-bundler/src/bundle/updater_bundle.rs:66\`), so the output is unversioned and arch-less. The DMG bundler is a separate code path that does include the version + arch in its filename.

Rather than fight that asymmetry with rename steps in CI, this PR lines the manifest URL up with the file as Tauri produces it. The version is still unambiguous because it lives in the release path (\`releases/download/v<version>/\`).

## Recovery for the failing release

This change only affects future releases. For the release that's currently 404'ing, regenerate \`latest.json\` and re-upload it to the release:

\`\`\`
TAG_NAME=v<failing-version>
RELEASE_BODY=\$(gh release view "\$TAG_NAME" --json body --jq .body)
gh release download "\$TAG_NAME" -p '*.app.tar.gz.sig'
bun run ./scripts/build-update-manifest.ts \\
  --version "\${TAG_NAME#v}" \\
  --signature Cork.app.tar.gz.sig \\
  --notes "\$RELEASE_BODY" \\
  --out ./latest.json
gh release upload "\$TAG_NAME" ./latest.json --clobber
\`\`\`

Or just cut another patch release once this is merged — \`release-please\` will regenerate the manifest with the correct URL automatically.

## Test plan

- [ ] Cut a patch release after merge; confirm in-app \`Install and Restart\` completes the download against \`Cork.app.tar.gz\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)